### PR TITLE
Revert last three kilo commits: 8280213, c15ccd3, 6b242a0

### DIFF
--- a/src/routes/ddnet/players/[name]/+page.ts
+++ b/src/routes/ddnet/players/[name]/+page.ts
@@ -132,37 +132,24 @@ export const load = (async ({ data, parent }) => {
 		[] as typeof maps
 	);
 
-	// points of last 365 days - calculate forward from 365 days ago
-	// Reuse day, today, firstActivity from activity section above
-
-	// Filter out unfinished maps (those without first_finish) and sort by first_finish timestamp (ascending)
-	const sortedMaps = [...maps]
-		.filter((m) => m.map.first_finish)
-		.sort((a, b) => a.map.first_finish! - b.map.first_finish!);
-
-	const growth: number[] = [];
-	let accumulatedPoints = 0;
+	// points of last 365 days
+	let currentPoints = player.points.points;
+	const endOfDay = new Date().setHours(23, 59, 59, 0) / 1000;
+	let currentDate = endOfDay;
 	let mapIndex = 0;
 
-	// Iterate through each day from 365 days ago to today
-	for (let i = 0; i < 365; i++) {
-		const currentDay = new Date(firstActivity.getTime() + i * day);
-		// Use end of day (23:59:59) for comparison to include all maps finished on this day
-		const currentDayEndTimestamp = new Date(currentDay).setHours(23, 59, 59, 999) / 1000;
+	const growth: number[] = [];
 
-		// Add points from all maps finished on or before this day
-		while (mapIndex < sortedMaps.length && sortedMaps[mapIndex].map.first_finish! <= currentDayEndTimestamp) {
-			accumulatedPoints += sortedMaps[mapIndex].map.points;
+	for (let i = 0; i < 365; i++) {
+		while (maps[mapIndex] && (maps[mapIndex].map.first_finish || 0) >= currentDate) {
+			currentPoints -= maps[mapIndex].map.points;
 			mapIndex++;
 		}
-
-		growth.push(accumulatedPoints);
+		growth.push(currentPoints);
+		currentDate -= 24 * 60 * 60;
 	}
 
-	// Always set the last day (today) to the current player points to reflect the latest total
-	if (growth.length > 0) {
-		growth[growth.length - 1] = player.points.points;
-	}
+	growth.reverse();
 
 	return {
 		player: {


### PR DESCRIPTION
This reverts:
- Fix accumulated points calculation: filter unfinished maps and use end of day timestamp
- Fix duplicate variable declarations in player points growth calculation
- Refactor player points growth calculation to iterate forward from 365 days ago