### PR TITLE
refactor: player detail page to CSR + API with retry, error/loading states, and cache

### DIFF
--- a/src/routes/ddnet/players/[name]/+page.svelte
+++ b/src/routes/ddnet/players/[name]/+page.svelte
@@ -325,29 +325,27 @@
 	});
 </script>
 
-{#if data}
-	<svelte:head>
-		<meta property="og:title" content="{data.player.player} - DDNet 玩家" />
-		<meta property="og:type" content="website" />
-		<meta
-			property="og:url"
-			content="https://teeworlds.cn/ddnet/players/{encodeAsciiURIComponent(data.player.player)}"
-		/>
-		<meta property="og:description" content={playerDescription} />
-		<meta property="og:image" content="https://teeworlds.cn/shareicon.png" />
-		<meta name="title" content="{data.player.player} - DDNet 玩家" />
-		<meta name="description" content={playerDescription} />
-	</svelte:head>
-
-	<Breadcrumbs
-		breadcrumbs={[
-			{ href: '/', text: '首页', title: 'TeeworldsCN' },
-			{ href: '/ddnet', text: 'DDNet' },
-			{ href: '/ddnet/players', text: '排名', title: 'DDNet 排名' },
-			{ text: data.player.player, title: data.player.player }
-		]}
+<svelte:head>
+	<meta property="og:title" content="{data.player.player} - DDNet 玩家" />
+	<meta property="og:type" content="website" />
+	<meta
+		property="og:url"
+		content="https://teeworlds.cn/ddnet/players/{encodeAsciiURIComponent(data.player.player)}"
 	/>
-{/if}
+	<meta property="og:description" content={playerDescription} />
+	<meta property="og:image" content="https://teeworlds.cn/shareicon.png" />
+	<meta name="title" content="{data.player.player} - DDNet 玩家" />
+	<meta name="description" content={playerDescription} />
+</svelte:head>
+
+<Breadcrumbs
+	breadcrumbs={[
+		{ href: '/', text: '首页', title: 'TeeworldsCN' },
+		{ href: '/ddnet', text: 'DDNet' },
+		{ href: '/ddnet/players', text: '排名', title: 'DDNet 排名' },
+		{ text: data.player.player, title: data.player.player }
+	]}
+/>
 
 {#if loading}
 	<div class="flex flex-col items-center justify-center py-32">
@@ -692,8 +690,6 @@
 	{#await import('$lib/components/tools/DDShare.svelte') then { default: DDShare }}
 		<DDShare name={data.player.player} {toolEntry} bind:toolPoints bind:pendingToolPoints></DDShare>
 	{/await}
-{/if}
-
 {/if}
 
 <Modal bind:show={pointModal}>


### PR DESCRIPTION
## Changes

This PR refactors the player detail page from SSR to CSR with a dedicated API endpoint, adding resilience and better UX:

- **CSR + API refactor**: Player detail page now loads data client-side via `/api/player-detail/{id}`
- **Retry logic**: API endpoint retries DDNet API calls (2 retries with jittered backoff)
- **Timeout handling**: 5-second timeout per request to avoid hanging
- **Loading spinner**: Shows spinner while data is loading
- **Error state**: Shows error message with retry button when loading fails
- **Cache header**: `Cache-Control: max-age=600` on the API response
- **Fix**: Move `<svelte:head>` out of `{#if}` block (Svelte 5 requirement)
- **Fix**: Transform raw API data in component, handle partial responses gracefully