### PR TITLE
fix: close unclosed {#if} block in player page

### DIFF
--- a/src/routes/ddnet/players/[name]/+page.svelte
+++ b/src/routes/ddnet/players/[name]/+page.svelte
@@ -822,6 +822,8 @@
 	</div>
 </Modal>
 
+{/if}
+
 <style>
 	.pulse-red {
 		animation: pulseRed 2s ease-in-out infinite;


### PR DESCRIPTION
## Fix

The previous PR #18 introduced a regression: the `{#if !loading && !loadError}` block on the player page was left unclosed, causing a Svelte compile error (`block_unclosed`).

This PR:
- Adds the missing `{/if}` closing tag
- Confirmed building successfully with `bun --bun run build`