### PR TITLE
fix: decode player name + populate growth chart on navigation

### DIFF
--- a/src/routes/ddnet/players/[name]/+page.server.ts
+++ b/src/routes/ddnet/players/[name]/+page.server.ts
@@ -14,5 +14,5 @@ export const load: PageServerLoad = async ({ parent, params }) => {
 		);
 	}
 
-	return {};
+	return { name: decodeAsciiURIComponent(param) };
 };

--- a/src/routes/ddnet/players/[name]/+page.svelte
+++ b/src/routes/ddnet/players/[name]/+page.svelte
@@ -240,11 +240,12 @@
 
 	let chart: Chart | null = null;
 
-	onMount(async () => {
-		await loadPlayerData(pageProps.name);
-		// Only init chart if data loaded successfully (canvas is in DOM)
-		if (!loadError) {
-			chart = new Chart(document.getElementById('growth-chart') as HTMLCanvasElement, {
+	function initChart() {
+		const canvas = document.getElementById('growth-chart') as HTMLCanvasElement | null;
+		if (!canvas) return;
+
+		if (chart) chart.destroy();
+		chart = new Chart(canvas, {
 			type: 'line',
 			options: {
 				maintainAspectRatio: false,
@@ -273,9 +274,14 @@
 				}
 			},
 			data: {
+				labels: data.growth.map((_, index) => {
+					return new Date(
+						(data.endOfDay - (364 - index) * 24 * 60 * 60) * 1000
+					).toLocaleDateString('zh-CN', { dateStyle: 'short' });
+				}),
 				datasets: [
 					{
-						data: [],
+						data: data.growth.map((point, index) => [index, point]),
 						segment: {
 							borderDash: (ctx) => (ctx.p1.parsed.y == 0 ? [5, 5] : undefined)
 						},
@@ -289,25 +295,26 @@
 			}
 		});
 	}
+
+	// Watch for player name changes (e.g. clicking a teammate link)
+	let currentName = $state(pageProps.name);
+	$effect(() => {
+		const newName = pageProps.name;
+		if (newName && newName !== currentName) {
+			currentName = newName;
+			if (chart) {
+				chart.destroy();
+				chart = null;
+			}
+			loadPlayerData(newName).then(() => {
+				if (!loadError) initChart();
+			});
+		}
 	});
 
-	$effect(() => {
-		data.growth;
-
-		if (chart) {
-			chart.data.labels = data.growth.map((_, index) => {
-				return new Date((data.endOfDay - (364 - index) * 24 * 60 * 60) * 1000).toLocaleDateString(
-					'zh-CN',
-					{
-						dateStyle: 'short'
-					}
-				);
-			});
-			chart.data.datasets[0].data = data.growth.map((point, index) => {
-				return [index, point];
-			});
-			chart.update();
-		}
+	onMount(async () => {
+		await loadPlayerData(pageProps.name);
+		if (!loadError) initChart();
 	});
 
 	const fakePoints = $derived(Math.floor((data.ranks[0].rank.points || 0) + toolPoints));


### PR DESCRIPTION
Follow-up to PR #19 (merged). Two additional fixes that were pushed after the merge:

1. **842f40a** fix: pass decoded player name from page server to CSR component — decodes base64url-encoded player name from URL before passing to CSR, fixing API requests using wrong player name
2. **240d5fd** fix: populate growth chart on mount and reload on player navigation — growth chart now populates on initial mount and reloads when navigating between players