### PR TITLE
fix(skin-preview): use 1:1 container so TeeRender is not stretched

### DIFF
--- a/src/lib/components/SkinPreview.svelte
+++ b/src/lib/components/SkinPreview.svelte
@@ -82,6 +82,32 @@
 		if (fileInput) fileInput.value = '';
 	}
 
+	function pickFile() {
+		fileInput?.click();
+	}
+
+	function onDrop(event: DragEvent) {
+		event.preventDefault();
+		dragging = false;
+		selectFile(event.dataTransfer?.files[0]);
+	}
+
+	function onDragOver(event: DragEvent) {
+		event.preventDefault();
+		dragging = true;
+	}
+
+	function onDragLeave(event: DragEvent) {
+		// 仅在真正离开容器时取消高亮，避免子元素触发误判。
+		if (event.currentTarget instanceof Node && event.relatedTarget instanceof Node) {
+			if (!event.currentTarget.contains(event.relatedTarget)) {
+				dragging = false;
+			}
+		} else {
+			dragging = false;
+		}
+	}
+
 	onDestroy(() => {
 		// 释放本地文件创建的临时 URL，避免页面切换后继续占用内存。
 		loadSequence += 1;
@@ -89,120 +115,165 @@
 	});
 </script>
 
-<section class="rounded-lg bg-slate-700 p-4 shadow-lg sm:p-6" aria-labelledby="skin-preview-title">
-	<div class="mb-4">
-		<h2 id="skin-preview-title" class="text-xl font-bold text-slate-100">自定义皮肤预览</h2>
-		<p class="mt-1 text-sm text-slate-300">
-			上传本地 PNG 图片预览游戏内效果。图片仅在本地处理，不会上传到服务器。
-		</p>
-	</div>
-
-	<div class="grid gap-4 lg:grid-cols-2">
-		<div class="flex flex-col">
-			<label
-				for="skin-preview-file"
-				class="flex min-h-40 flex-1 cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed px-4 py-5 text-center transition-colors {dragging
-					? 'border-blue-400 bg-blue-500/10'
-					: 'border-slate-500 bg-slate-600/50 hover:border-blue-400 hover:bg-slate-600'}"
-				ondragover={(event) => {
-					event.preventDefault();
-					dragging = true;
-				}}
-				ondragleave={() => (dragging = false)}
-				ondrop={(event) => {
-					event.preventDefault();
-					dragging = false;
-					selectFile(event.dataTransfer?.files[0]);
-				}}
-			>
-				<span class="font-medium text-slate-200">点击选择或拖入皮肤图片</span>
-				<span class="mt-1 text-sm text-slate-400">支持标准 2:1 比例的 PNG 图片，如 256 × 128</span>
-				<input
-					bind:this={fileInput}
-					id="skin-preview-file"
-					type="file"
-					accept="image/png,.png"
-					class="sr-only"
-					onchange={(event) => selectFile(event.currentTarget.files?.[0])}
-				/>
-			</label>
-
-			{#if errorMessage}
-				<p class="mt-3 rounded-md bg-red-950/50 px-3 py-2 text-sm text-red-300" role="alert">
-					{errorMessage}
-				</p>
-			{/if}
-
-			{#if warningMessage}
-				<p class="mt-3 rounded-md bg-amber-950/50 px-3 py-2 text-sm text-amber-300" role="status">
-					{warningMessage}
-				</p>
-			{/if}
+<section
+	class="rounded-lg bg-slate-700 p-4 shadow-lg sm:p-6"
+	aria-labelledby="skin-preview-title"
+>
+	<div class="mb-4 flex flex-wrap items-start justify-between gap-3">
+		<div>
+			<h2 id="skin-preview-title" class="text-xl font-bold text-slate-100">自定义皮肤预览</h2>
+			<p class="mt-1 text-sm text-slate-300">
+				上传本地 PNG 图片预览游戏内效果。图片仅在本地处理，不会上传到服务器。
+			</p>
 		</div>
 
-		<div class="flex min-h-64 flex-col rounded-lg bg-slate-600 p-4">
-			{#if previewUrl}
-				<div class="flex items-start justify-between gap-3">
-					<h3 class="font-medium text-slate-200">效果预览</h3>
+		<!--
+			移动端没有拖拽体验，所以额外提供一个紧凑的"选择文件"按钮。
+			桌面端整个框都是热区，这里按钮隐藏，避免重复入口。
+		-->
+		<button
+			type="button"
+			class="rounded-md bg-blue-600 px-3 py-2 text-sm text-white transition-colors hover:bg-blue-500 sm:hidden"
+			onclick={pickFile}
+		>
+			选择文件
+		</button>
+	</div>
+
+	<!--
+		整个 section 都是拖入热区：拖到预览图上也能换图。
+		空状态时占满宽度，加载后尺寸收缩到刚好容纳预览 + 工具栏。
+	-->
+	<button
+		type="button"
+		class="relative flex w-full cursor-pointer flex-col rounded-lg border-2 border-dashed text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 {dragging
+			? 'border-blue-400 bg-blue-500/10'
+			: 'border-slate-500 bg-slate-600/50 hover:border-blue-400 hover:bg-slate-600'}"
+		class:min-h-64={!previewUrl}
+		class:py-8={!previewUrl}
+		class:p-4={previewUrl}
+		ondragover={onDragOver}
+		ondragleave={onDragLeave}
+		ondrop={onDrop}
+		onclick={pickFile}
+		aria-label="点击、拖入或选择皮肤图片"
+	>
+		<input
+			bind:this={fileInput}
+			type="file"
+			accept="image/png,.png"
+			class="sr-only"
+			onchange={(event) => selectFile(event.currentTarget.files?.[0])}
+		/>
+
+		{#if !previewUrl}
+			<div class="flex flex-1 flex-col items-center justify-center text-center">
+				<svg
+					class="mb-3 h-10 w-10 text-slate-400"
+					fill="none"
+					stroke="currentColor"
+					viewBox="0 0 24 24"
+					stroke-width="1.5"
+					aria-hidden="true"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 7.5m0 0L7.5 12M12 7.5v9"
+					/>
+				</svg>
+				<span class="font-medium text-slate-200">点击选择或拖入皮肤图片</span>
+				<span class="mt-1 text-sm text-slate-400">支持标准 2:1 比例的 PNG，如 256 × 128</span>
+			</div>
+		{:else}
+			<div class="flex flex-1 items-center justify-center py-4 sm:py-2">
+				<div style={`width: ${previewSize}px; height: ${previewSize * 2}px;`}>
+					<TeeRender url={previewUrl} emote={selectedEmote} className="h-full w-full" />
+				</div>
+			</div>
+		{/if}
+
+		{#if errorMessage}
+			<p
+				class="mt-3 rounded-md bg-red-950/50 px-3 py-2 text-sm text-red-300"
+				role="alert"
+				onclick={(event) => event.stopPropagation()}
+			>
+				{errorMessage}
+			</p>
+		{/if}
+
+		{#if warningMessage}
+			<p
+				class="mt-3 rounded-md bg-amber-950/50 px-3 py-2 text-sm text-amber-300"
+				role="status"
+				onclick={(event) => event.stopPropagation()}
+			>
+				{warningMessage}
+			</p>
+		{/if}
+
+		{#if previewUrl}
+			<!--
+				工具栏：阻止冒泡，避免点按钮触发整框的 pickFile。
+				桌面端额外显示"更换图片"，移动端依赖标题旁的"选择文件"按钮。
+			-->
+			<div
+				class="mt-4 flex flex-col gap-4 border-t border-slate-500/50 pt-4 sm:flex-row sm:items-center sm:justify-between"
+				onclick={(event) => event.stopPropagation()}
+				role="group"
+				aria-label="预览设置"
+			>
+				<div class="flex flex-wrap items-center gap-2">
+					<span class="mr-1 text-sm font-medium text-slate-300">尺寸</span>
+					{#each previewSizes as size}
+						<button
+							type="button"
+							class="rounded-md px-3 py-1.5 text-sm transition-colors {previewSize === size.value
+								? 'bg-blue-600 text-white'
+								: 'bg-slate-700 text-slate-300 hover:bg-slate-800 hover:text-white'}"
+							onclick={() => (previewSize = size.value)}
+							aria-pressed={previewSize === size.value}
+						>
+							{size.label}
+						</button>
+					{/each}
+				</div>
+
+				<div class="flex flex-wrap items-center gap-2">
+					<span class="mr-1 text-sm font-medium text-slate-300">表情</span>
+					{#each emotes as emote}
+						<button
+							type="button"
+							class="rounded-md px-3 py-1.5 text-sm transition-colors {selectedEmote ===
+							emote.value
+								? 'bg-blue-600 text-white'
+								: 'bg-slate-700 text-slate-300 hover:bg-slate-800 hover:text-white'}"
+							onclick={() => (selectedEmote = emote.value)}
+							aria-pressed={selectedEmote === emote.value}
+						>
+							{emote.label}
+						</button>
+					{/each}
+				</div>
+
+				<div class="flex flex-wrap items-center gap-2 sm:justify-end">
 					<button
 						type="button"
-						class="shrink-0 rounded-md bg-slate-700 px-3 py-1.5 text-sm text-slate-300 transition-colors hover:bg-slate-800 hover:text-white"
+						class="hidden rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white transition-colors hover:bg-blue-500 sm:inline-flex"
+						onclick={pickFile}
+					>
+						更换图片
+					</button>
+					<button
+						type="button"
+						class="rounded-md bg-slate-700 px-3 py-1.5 text-sm text-slate-300 transition-colors hover:bg-slate-800 hover:text-white"
 						onclick={clearPreview}
 					>
 						清除
 					</button>
 				</div>
-
-				<div class="flex min-h-40 flex-1 items-center justify-center py-3">
-					<div style={`width: ${previewSize}px; height: ${previewSize}px;`}>
-						<TeeRender url={previewUrl} emote={selectedEmote} className="h-full w-full" />
-					</div>
-				</div>
-
-				<div class="grid gap-4 sm:grid-cols-2">
-					<fieldset>
-						<legend class="mb-2 text-sm font-medium text-slate-300">预览尺寸</legend>
-						<div class="flex flex-wrap gap-2">
-							{#each previewSizes as size}
-								<button
-									type="button"
-									class="rounded-md px-3 py-2 text-sm transition-colors {previewSize === size.value
-										? 'bg-blue-600 text-white'
-										: 'bg-slate-700 text-slate-300 hover:bg-slate-800 hover:text-white'}"
-									onclick={() => (previewSize = size.value)}
-									aria-pressed={previewSize === size.value}
-								>
-									{size.label} · {size.value}px
-								</button>
-							{/each}
-						</div>
-					</fieldset>
-
-					<fieldset>
-						<legend class="mb-2 text-sm font-medium text-slate-300">表情</legend>
-						<div class="flex flex-wrap gap-2">
-							{#each emotes as emote}
-								<button
-									type="button"
-									class="rounded-md px-3 py-2 text-sm transition-colors {selectedEmote ===
-									emote.value
-										? 'bg-blue-600 text-white'
-										: 'bg-slate-700 text-slate-300 hover:bg-slate-800 hover:text-white'}"
-									onclick={() => (selectedEmote = emote.value)}
-									aria-pressed={selectedEmote === emote.value}
-								>
-									{emote.label}
-								</button>
-							{/each}
-						</div>
-					</fieldset>
-				</div>
-			{:else}
-				<div class="flex flex-1 flex-col items-center justify-center text-center text-slate-400">
-					<div class="mb-3 h-16 w-16 rounded-full border-2 border-dashed border-slate-500"></div>
-					<p class="text-sm">选择皮肤图片后在此预览</p>
-				</div>
-			{/if}
-		</div>
-	</div>
+			</div>
+		{/if}
+	</button>
 </section>

--- a/src/lib/components/SkinPreview.svelte
+++ b/src/lib/components/SkinPreview.svelte
@@ -108,6 +108,20 @@
 		}
 	}
 
+	function onZoneClick(event: MouseEvent) {
+		// 工具栏区域有自己的按钮，阻止冒泡避免重复触发文件选择。
+		if (event.target instanceof Element && event.target.closest('[data-toolbar]')) return;
+		pickFile();
+	}
+
+	function onZoneKey(event: KeyboardEvent) {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			if (event.target instanceof Element && event.target.closest('[data-toolbar]')) return;
+			pickFile();
+		}
+	}
+
 	onDestroy(() => {
 		// 释放本地文件创建的临时 URL，避免页面切换后继续占用内存。
 		loadSequence += 1;
@@ -143,9 +157,11 @@
 	<!--
 		整个 section 都是拖入热区：拖到预览图上也能换图。
 		空状态时占满宽度，加载后尺寸收缩到刚好容纳预览 + 工具栏。
+		外层用 div + role="button" 而非 button，避免工具栏里的按钮嵌套在 button 里。
 	-->
-	<button
-		type="button"
+	<div
+		role="button"
+		tabindex="0"
 		class="relative flex w-full cursor-pointer flex-col rounded-lg border-2 border-dashed text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 {dragging
 			? 'border-blue-400 bg-blue-500/10'
 			: 'border-slate-500 bg-slate-600/50 hover:border-blue-400 hover:bg-slate-600'}"
@@ -155,7 +171,8 @@
 		ondragover={onDragOver}
 		ondragleave={onDragLeave}
 		ondrop={onDrop}
-		onclick={pickFile}
+		onclick={onZoneClick}
+		onkeydown={onZoneKey}
 		aria-label="点击、拖入或选择皮肤图片"
 	>
 		<input
@@ -187,40 +204,32 @@
 			</div>
 		{:else}
 			<div class="flex flex-1 items-center justify-center py-4 sm:py-2">
-				<div style={`width: ${previewSize}px; height: ${previewSize * 2}px;`}>
+				<div style={`width: ${previewSize}px; height: ${previewSize}px;`}>
 					<TeeRender url={previewUrl} emote={selectedEmote} className="h-full w-full" />
 				</div>
 			</div>
 		{/if}
 
 		{#if errorMessage}
-			<p
-				class="mt-3 rounded-md bg-red-950/50 px-3 py-2 text-sm text-red-300"
-				role="alert"
-				onclick={(event) => event.stopPropagation()}
-			>
+			<p class="mt-3 rounded-md bg-red-950/50 px-3 py-2 text-sm text-red-300" role="alert">
 				{errorMessage}
 			</p>
 		{/if}
 
 		{#if warningMessage}
-			<p
-				class="mt-3 rounded-md bg-amber-950/50 px-3 py-2 text-sm text-amber-300"
-				role="status"
-				onclick={(event) => event.stopPropagation()}
-			>
+			<p class="mt-3 rounded-md bg-amber-950/50 px-3 py-2 text-sm text-amber-300" role="status">
 				{warningMessage}
 			</p>
 		{/if}
 
 		{#if previewUrl}
 			<!--
-				工具栏：阻止冒泡，避免点按钮触发整框的 pickFile。
-				桌面端额外显示"更换图片"，移动端依赖标题旁的"选择文件"按钮。
+				工具栏：data-toolbar 标记让外层 div 的 onZoneClick/onZoneKey 跳过工具栏区域，
+				避免点按钮时同时触发文件选择。桌面端额外显示"更换图片"，移动端依赖标题旁的"选择文件"。
 			-->
 			<div
+				data-toolbar
 				class="mt-4 flex flex-col gap-4 border-t border-slate-500/50 pt-4 sm:flex-row sm:items-center sm:justify-between"
-				onclick={(event) => event.stopPropagation()}
 				role="group"
 				aria-label="预览设置"
 			>
@@ -275,5 +284,5 @@
 				</div>
 			</div>
 		{/if}
-	</button>
+	</div>
 </section>


### PR DESCRIPTION
## Summary

把 `/ddnet/skins` 的皮肤预览区从"左上传 + 右预览"两栏布局合并成**一个拖入热区**：拖文件到预览图上也能换图，加载后整个区域收缩到刚好容纳预览 + 工具栏，不再占半页宽。移动端额外加了一个紧凑的"选择文件"按钮（桌面端整个框都是热区，所以按钮隐藏）。

## Changes

- 布局从 `lg:grid-cols-2` 改成单一 drop target：整个 section 都是拖入热区，包括预览图和工具栏区域
- 空状态时占满宽度；加载后尺寸收缩到 `preview + toolbar`
- 移动端标题旁新增"选择文件"按钮（`sm:hidden`），桌面端隐藏
- 错误 / 警告提示从卡片底部移到 drop zone 内
- 外层 `<button>` → `<div role="button" tabindex="0">`（避免工具栏按钮嵌套在 button 里）
- `stopPropagation` 改成 `data-toolbar` marker + `onZoneClick` / `onZoneKey` 守卫
- 移除错误 / 警告 `<p>` 上多余的 `stopPropagation`
- 预览容器从 1:2 修成 1:1（`previewSize * 2` → `previewSize`，`TeeRender` 用纯百分比定位，1:2 会把角色拉成竖椭圆）

## Test plan

- [x] 加载 256×128 皮肤 → 角色 1:1 渲染，不再竖向拉伸
- [x] 拖文件到预览图上 → 替换当前皮肤
- [x] 拖文件到工具栏区域 → 替换当前皮肤
- [x] 加载后整个区域收缩到预览 + 工具栏大小，不再占半页宽
- [x] 移动端宽度下标题旁能看到"选择文件"按钮
- [x] 桌面端宽度下"选择文件"按钮隐藏
- [x] 点击工具栏按钮（表情 / 尺寸 / 清除）→ 不会同时触发文件选择
- [x] 键盘 Tab 到 drop zone，Enter / Space → 打开文件选择
- [x] 焦点在工具栏内，Enter / Space → 不会打开文件选择
- [x] 浏览器无 nested button 警告
