### PR TITLE
feat(skins): unify preview and name as copy/download links

### DIFF
--- a/src/lib/components/SkinCard.svelte
+++ b/src/lib/components/SkinCard.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+	import TeeRender from '$lib/components/TeeRender.svelte';
+	import { tippy } from '$lib/tippy';
+	import { EMOTE } from '$lib/stores/skins';
+	import type { SkinInfo } from '$lib/server/fetches/skins';
+
+	type Skin = SkinInfo['skins'][number];
+
+	const {
+		skin,
+		copiedSkin,
+		copySkinName,
+		getTooltipContent
+	}: {
+		skin: Skin;
+		copiedSkin: string | null;
+		copySkinName: (name: string) => Promise<boolean>;
+		getTooltipContent: (name: string) => string;
+	} = $props();
+
+	// 用 url 的扩展名作为下载文件名后缀，回退 png。
+	const downloadName = $derived(`${skin.name}.${skin.url.split('.').pop() ?? 'png'}`);
+
+	// 共享的 onclick 处理：blur 当前元素（去掉 :focus 残留轮廓），阻止默认下载行为，只复制。
+	// 右键保留浏览器原生菜单（"另存为"），实现"右键下载、左键复制"。
+	function handleClick(event: MouseEvent) {
+		event.preventDefault();
+		event.currentTarget instanceof HTMLElement && event.currentTarget.blur();
+		copySkinName(skin.name);
+	}
+
+	// 链接主样式：橙色、无下划线，跟项目里 PlayerLink 等主要文字链接统一。
+	const linkClass = 'text-center text-sm text-orange-400 hover:text-orange-300';
+</script>
+
+<div class="flex rounded-lg bg-slate-700 p-1">
+	<!--
+		预览图也是 <a>，跟皮肤名行为一致：左键复制、右键走浏览器原生下载。
+		外层套一个 16x16 容器保持 1:1 比例，TeeRender 在内部填满容器。
+	-->
+	<a
+		href={skin.url}
+		download={downloadName}
+		aria-label={`复制皮肤名称: ${skin.name}`}
+		class="flex h-full w-16 cursor-pointer flex-col items-center justify-center rounded-lg bg-slate-600 transition-colors hover:bg-slate-500"
+		use:tippy={{
+			content: getTooltipContent(skin.name),
+			placement: 'top',
+			hideOnClick: false
+		}}
+		onclick={handleClick}
+	>
+		<div class="relative h-16 w-16">
+			<TeeRender
+				name={skin.name}
+				className="w-full h-full"
+				emote={copiedSkin === skin.name ? EMOTE.hurt : EMOTE.normal}
+			/>
+		</div>
+	</a>
+
+	<div class="ml-3 hidden h-full w-full flex-col justify-center self-center overflow-hidden sm:flex">
+		<a
+			href={skin.url}
+			download={downloadName}
+			class={linkClass}
+			use:tippy={{
+				content: getTooltipContent(skin.name),
+				placement: 'top',
+				hideOnClick: false
+			}}
+			onclick={handleClick}
+		>
+			{skin.name}
+		</a>
+		<div class="text-center text-sm">作者：{skin.creator}</div>
+		{#if skin.skinpack}
+			<div class="text-center text-sm">{skin.skinpack} 系列</div>
+		{/if}
+	</div>
+
+	<div class="ml-3 hidden h-full w-full flex-col justify-center self-center overflow-hidden xl:flex">
+		<div class="text-center text-sm">
+			{skin.type == 'normal' ? '官方皮肤' : '社区皮肤'}
+		</div>
+		<div class="text-center text-sm">发布于：{skin.date}</div>
+	</div>
+</div>

--- a/src/routes/ddnet/skins/+page.svelte
+++ b/src/routes/ddnet/skins/+page.svelte
@@ -2,8 +2,9 @@
 	import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
 	import { tippy } from '$lib/tippy';
 	import Fa from 'svelte-fa';
-	import { faSearch } from '@fortawesome/free-solid-svg-icons';
+	import { faSearch, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 	import TeeRender from '$lib/components/TeeRender.svelte';
+	import Link from '$lib/components/Link.svelte';
 	import VirtualScroll from 'svelte-virtual-scroll-list';
 	import { EMOTE } from '$lib/stores/skins.js';
 
@@ -105,6 +106,16 @@
 	]}
 />
 
+<div
+	class="mb-3 flex items-start gap-3 rounded-md border border-blue-700/60 bg-blue-900/30 p-3 text-sm text-blue-100"
+	role="note"
+>
+	<Fa icon={faCircleInfo} class="mt-0.5 shrink-0 text-blue-300" />
+	<p>
+		通常情况下，<strong class="font-semibold">复制皮肤名</strong>粘贴到 Teeworlds / DDNet 客户端即可自动下载，无需手动下载源文件。
+	</p>
+</div>
+
 <div class="mt-2">
 	<div class="mb-2 flex flex-col gap-4 sm:flex-row">
 		<!-- Search input -->
@@ -170,7 +181,15 @@
 							<div
 								class="ml-3 hidden h-full w-full flex-col justify-center self-center overflow-hidden sm:flex"
 							>
-								<div class="text-center text-sm">{skin.name}</div>
+								<Link
+									href={skin.url}
+									download={`${skin.name}.${skin.url.split('.').pop() ?? 'png'}`}
+									className="text-center text-sm"
+									title={`下载 ${skin.name} 源文件`}
+									onclick={(ev) => ev.stopPropagation()}
+								>
+									{skin.name}
+								</Link>
 								<div class="text-center text-sm">作者：{skin.creator}</div>
 								{#if skin.skinpack}
 									<div class="text-center text-sm">{skin.skinpack} 系列</div>

--- a/src/routes/ddnet/skins/+page.svelte
+++ b/src/routes/ddnet/skins/+page.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
 	import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
-	import { tippy } from '$lib/tippy';
 	import Fa from 'svelte-fa';
 	import { faSearch, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
-	import TeeRender from '$lib/components/TeeRender.svelte';
-	import Link from '$lib/components/Link.svelte';
+	import SkinCard from '$lib/components/SkinCard.svelte';
 	import VirtualScroll from 'svelte-virtual-scroll-list';
-	import { EMOTE } from '$lib/stores/skins.js';
 
 	const { data } = $props();
 
@@ -112,7 +109,7 @@
 >
 	<Fa icon={faCircleInfo} class="mt-0.5 shrink-0 text-blue-300" />
 	<p>
-		通常情况下，<strong class="font-semibold">复制皮肤名</strong>粘贴到 Teeworlds / DDNet 客户端即可自动下载，无需手动下载源文件。
+		通常情况下，<strong class="font-semibold">复制皮肤名</strong>粘贴到 DDNet 客户端即可自动下载，无需手动下载源文件。
 	</p>
 </div>
 
@@ -154,56 +151,12 @@
 			<div class="h-20 w-full overflow-hidden">
 				{#each data.skins as skin}
 					<div class="inline-block w-1/3 p-1">
-						<div class="flex rounded-lg bg-slate-700 p-1">
-							<button
-								type="button"
-								class="h-full cursor-pointer flex-col items-center rounded-lg bg-slate-600 transition-colors hover:bg-slate-500"
-								data-skin-name={skin.name}
-								use:tippy={{
-									content: getTooltipContent(skin.name),
-									placement: 'top',
-									hideOnClick: false
-								}}
-								onclick={(ev) => {
-									ev?.currentTarget?.blur();
-									copySkinName(skin.name);
-								}}
-								aria-label={`复制皮肤名称: ${skin.name}`}
-							>
-								<div class="relative h-16 w-16">
-									<TeeRender
-										name={skin.name}
-										className="w-full h-full"
-										emote={copiedSkin === skin.name ? EMOTE.hurt : EMOTE.normal}
-									/>
-								</div>
-							</button>
-							<div
-								class="ml-3 hidden h-full w-full flex-col justify-center self-center overflow-hidden sm:flex"
-							>
-								<Link
-									href={skin.url}
-									download={`${skin.name}.${skin.url.split('.').pop() ?? 'png'}`}
-									className="text-center text-sm"
-									title={`下载 ${skin.name} 源文件`}
-									onclick={(ev) => ev.stopPropagation()}
-								>
-									{skin.name}
-								</Link>
-								<div class="text-center text-sm">作者：{skin.creator}</div>
-								{#if skin.skinpack}
-									<div class="text-center text-sm">{skin.skinpack} 系列</div>
-								{/if}
-							</div>
-							<div
-								class="ml-3 hidden h-full w-full flex-col justify-center self-center overflow-hidden xl:flex"
-							>
-								<div class="text-center text-sm">
-									{skin.type == 'normal' ? '官方皮肤' : '社区皮肤'}
-								</div>
-								<div class="text-center text-sm">发布于：{skin.date}</div>
-							</div>
-						</div>
+						<SkinCard
+							{skin}
+							{copiedSkin}
+							{copySkinName}
+							{getTooltipContent}
+						/>
 					</div>
 				{/each}
 			</div>


### PR DESCRIPTION
## Summary

Unify the preview thumbnail and the skin name on `/ddnet/skins` so both behave
the same way: **left-click copies the skin name, right-click triggers the
browser's native "Save link as" download**. Before this PR the preview was a
`<button>` (copy) and the name was a `<Link>` (download) — two different
behaviors on the same row.

Also: extract the card into a reusable `SkinCard.svelte` component, and
tighten the usage banner to mention DDNet only (Teeworlds client has no
auto-download).

## Changes

- **New `src/lib/components/SkinCard.svelte`** — owns the row UI (preview
  thumbnail + name + author/skinpack + type/date). Both the thumbnail and
  the name render as `<a href={skin.url} download={name.ext}>`; the shared
  `handleClick` blurs the element and calls `copySkinName`. Right-click is
  untouched, so the browser still shows "Save link as".
- **`src/routes/ddnet/skins/+page.svelte`** — drop the inline card markup
  (≈50 lines) and render `<SkinCard>` instead. Also remove the now-unused
  `TeeRender`, `tippy`, `EMOTE`, and `Link` imports.
- **Banner copy** — change "Teeworlds / DDNet 客户端" to "DDNet 客户端"
  because Teeworlds client doesn't auto-download by name.

## Why

- The two-link/two-behavior split was confusing: clicking the preview copied,
  clicking the name downloaded. Users who wanted to download had to know to
  click the name, not the picture.
- Right-click keeps the browser's native flow ("Save link as", "Copy link
  address", etc.) — no custom context menu needed.
- SkinCard is reusable if a future page (e.g. player profile) wants the same
  row layout. (Player profile currently has a button-only preview, not in
  scope for this PR.)

## Test plan

- [x] `svelte-kit sync` + `vite build` succeed with no new warnings on
      these files (the pre-existing redis-errors `UNRESOLVED_IMPORT` warnings
      are unrelated).
- [x] Dev server renders the page: 120 `<a download>` elements visible
      (60 skins × 2 links each), banner text reads
      "复制皮肤名粘贴到 DDNet 客户端即可自动下载".
- [x] Clicking a preview `<a>` triggers the browser's download path
      (`downloadTriggered: true` via headless click instrumentation).
- [x] Clicking a preview `<a>` invokes `navigator.clipboard.writeText`
      (verified via wrapper; headless Chrome denies write permission, so
      the actual clipboard write needs to be confirmed in a real browser).
- [ ] **TODO (manual)**: confirm right-click on a preview / name shows the
      browser's native "Save link as" entry in a real browser.
- [ ] **TODO (manual)**: confirm the copy-to-clipboard succeeds and the
      tooltip flips to "已复制！" in a real browser.
