### PR TITLE
feat(skins): single-column mobile layout with full info

### DIFF
--- a/src/lib/components/SkinCard.svelte
+++ b/src/lib/components/SkinCard.svelte
@@ -59,7 +59,7 @@
 		</div>
 	</a>
 
-	<div class="ml-3 hidden h-full w-full flex-col justify-center self-center overflow-hidden sm:flex">
+	<div class="ml-3 flex h-full w-full flex-col justify-center self-center overflow-hidden">
 		<a
 			href={skin.url}
 			download={downloadName}
@@ -79,7 +79,7 @@
 		{/if}
 	</div>
 
-	<div class="ml-3 hidden h-full w-full flex-col justify-center self-center overflow-hidden xl:flex">
+	<div class="ml-3 flex h-full w-full flex-col justify-center self-center overflow-hidden sm:hidden xl:flex">
 		<div class="text-center text-sm">
 			{skin.type == 'normal' ? '官方皮肤' : '社区皮肤'}
 		</div>

--- a/src/lib/components/SkinCard.svelte
+++ b/src/lib/components/SkinCard.svelte
@@ -10,12 +10,16 @@
 		skin,
 		copiedSkin,
 		copySkinName,
-		getTooltipContent
+		getTooltipContent,
+		searchByAuthor,
+		searchByPack
 	}: {
 		skin: Skin;
 		copiedSkin: string | null;
 		copySkinName: (name: string) => Promise<boolean>;
 		getTooltipContent: (name: string) => string;
+		searchByAuthor?: (name: string) => void;
+		searchByPack?: (name: string) => void;
 	} = $props();
 
 	// 用 url 的扩展名作为下载文件名后缀，回退 png。
@@ -30,40 +34,77 @@
 	}
 
 	// 链接主样式：橙色、无下划线，跟项目里 PlayerLink 等主要文字链接统一。
-	const linkClass = 'text-center text-sm text-orange-400 hover:text-orange-300';
+	const linkClass = 'text-orange-400 hover:text-orange-300';
+
+	// 角标日期：保留完整年份 (YYYY-MM-DD)，方便跨年查找。
+	const shortDate = $derived(skin.date.slice(0, 10));
+
+	// 类型角标：normal=DDNet 官方，community=社区玩家自制，不同色区分。
+	// 颜色用 bg+text 组合保证对比度，title 提供完整语义。
+	const typeBadge = $derived(
+		skin.type === 'normal'
+			? { label: '官方', cls: 'bg-blue-900/80 text-blue-200', title: 'DDNet 官方皮肤' }
+			: { label: '社区', cls: 'bg-purple-900/80 text-purple-200', title: '社区玩家自制皮肤' }
+	);
 </script>
 
-<div class="flex rounded-lg bg-slate-700 p-1">
+<div class="relative flex items-center gap-3 rounded-lg bg-slate-700 p-1 pr-9">
 	<!--
 		预览图也是 <a>，跟皮肤名行为一致：左键复制、右键走浏览器原生下载。
-		外层套一个 16x16 容器保持 1:1 比例，TeeRender 在内部填满容器。
+		外层套一个 64x64 容器保持 1:1 比例，TeeRender 在内部填满容器。
+		容器用 shrink-0 保证不被挤压；relative 让角标能绝对定位。
 	-->
-	<a
-		href={skin.url}
-		download={downloadName}
-		aria-label={`复制皮肤名称: ${skin.name}`}
-		class="flex h-full w-16 cursor-pointer flex-col items-center justify-center rounded-lg bg-slate-600 transition-colors hover:bg-slate-500"
-		use:tippy={{
-			content: getTooltipContent(skin.name),
-			placement: 'top',
-			hideOnClick: false
-		}}
-		onclick={handleClick}
-	>
-		<div class="relative h-16 w-16">
+	<div class="h-16 w-16 shrink-0">
+		<a
+			href={skin.url}
+			download={downloadName}
+			aria-label={`复制皮肤名称: ${skin.name}`}
+			class="flex h-full w-full cursor-pointer flex-col items-center justify-center rounded-lg bg-slate-600 transition-colors hover:bg-slate-500"
+			use:tippy={{
+				content: getTooltipContent(skin.name),
+				placement: 'top',
+				hideOnClick: false
+			}}
+			onclick={handleClick}
+		>
 			<TeeRender
 				name={skin.name}
 				className="w-full h-full"
 				emote={copiedSkin === skin.name ? EMOTE.hurt : EMOTE.normal}
 			/>
+		</a>
 		</div>
-	</a>
 
-	<div class="ml-3 flex h-full w-full flex-col justify-center self-center overflow-hidden">
+	<!--
+		右上角系列角标：仅当 skinpack 存在时显示。放在卡片右上角（预览图外），
+		不遮挡预览图。
+	-->
+	{#if skin.skinpack}
+		{#if searchByPack}
+			<button
+				type="button"
+				class="absolute top-0.5 right-1 truncate px-1 text-[10px] leading-tight italic text-slate-500 transition-colors hover:text-slate-300"
+				title={`筛选系列: ${skin.skinpack}`}
+				onclick={() => searchByPack(skin.skinpack)}
+			>{skin.skinpack}</button>
+		{:else}
+			<span
+				class="absolute top-0.5 right-1 truncate px-1 text-[10px] leading-tight italic text-slate-500"
+				title={skin.skinpack}
+			>{skin.skinpack}</span>
+		{/if}
+	{/if}
+
+	<!--
+		文本块：多行布局。
+		第一行：皮肤名（链接）
+		第二行：作者 · skinpack
+	-->
+	<div class="flex min-w-0 flex-1 flex-col gap-1 text-sm">
 		<a
 			href={skin.url}
 			download={downloadName}
-			class={linkClass}
+			class="{linkClass} truncate font-medium"
 			use:tippy={{
 				content: getTooltipContent(skin.name),
 				placement: 'top',
@@ -73,16 +114,41 @@
 		>
 			{skin.name}
 		</a>
-		<div class="text-center text-sm">作者：{skin.creator}</div>
-		{#if skin.skinpack}
-			<div class="text-center text-sm">{skin.skinpack} 系列</div>
-		{/if}
+		<div class="flex min-w-0 items-center gap-1 text-xs text-slate-400">
+			{#if skin.creator}
+				{#if searchByAuthor}
+					<button
+						type="button"
+						class="truncate text-left hover:text-slate-200 hover:underline"
+						title={`筛选作者: ${skin.creator}`}
+						onclick={() => searchByAuthor(skin.creator)}
+					>{skin.creator}</button>
+				{:else}
+					<span class="truncate">{skin.creator}</span>
+				{/if}
+			{/if}
+		</div>
 	</div>
 
-	<div class="ml-3 flex h-full w-full flex-col justify-center self-center overflow-hidden sm:hidden xl:flex">
-		<div class="text-center text-sm">
-			{skin.type == 'normal' ? '官方皮肤' : '社区皮肤'}
-		</div>
-		<div class="text-center text-sm">发布于：{skin.date}</div>
+	<!--
+		角标：卡片右下角日期 + 皮肤类型（叠在一起，日期在上、类型在下）。
+		绝对定位在卡片右下角，不挤压主内容。
+		用 flex-col 让两个角标垂直堆叠，gap-0.5 让它们之间有一点间距。
+	-->
+	<div
+		class="pointer-events-none absolute right-1 bottom-1 flex flex-col items-end gap-0.5"
+	>
+		<span
+			class="rounded px-1 text-[10px] leading-tight {typeBadge.cls}"
+			title={typeBadge.title}
+		>
+			{typeBadge.label}
+		</span>
+		<span
+			class="rounded bg-slate-900/80 px-1 text-[10px] leading-tight text-slate-300"
+			title={`发布于 ${skin.date}`}
+		>
+			{shortDate}
+		</span>
 	</div>
 </div>

--- a/src/lib/tippy.ts
+++ b/src/lib/tippy.ts
@@ -54,7 +54,12 @@ export const tippy: Tippy = (element, props = {}) => {
 	let arrowElement: HTMLElement | null = null;
 	let cleanup: (() => void) | null = null;
 	let isVisible = false;
-	let currentProps = { arrow: true, appendTo: 'parent', touch: 'tap', ...props };
+	// Default appendTo: 'body' to avoid parent overflow:hidden clipping
+	// (e.g. virtual-scroll rows with fixed height). Floating UI's
+	// computePosition uses the absolute position of the reference element,
+	// so rendering at body level still positions correctly.
+	// Per-call `appendTo` can still override this.
+	let currentProps = { arrow: true, appendTo: 'body', touch: 'tap', ...props };
 	let appendTo: Element | null = null;
 
 	// Touch-specific state

--- a/src/routes/ddnet/skins/+page.svelte
+++ b/src/routes/ddnet/skins/+page.svelte
@@ -237,7 +237,7 @@
 	<!-- Skins grid with virtual scrolling -->
 	<div class="scrollbar-subtle h-[calc(100svh-16rem)] w-full sm:h-[calc(100svh-14rem)]">
 		<VirtualScroll keeps={20} data={filteredSkins} key="row" let:data>
-			<div class="h-20 w-full overflow-hidden">
+			<div class="w-full sm:h-20 sm:overflow-hidden">
 				{#each data.skins as skin}
 					<div class="block w-full p-1 sm:inline-block sm:w-1/3">
 						<SkinCard

--- a/src/routes/ddnet/skins/+page.svelte
+++ b/src/routes/ddnet/skins/+page.svelte
@@ -18,6 +18,65 @@
 	$effect(() => {
 		if (!data.skins) return;
 
+		// 解析搜索语法：
+		//   author:X       → 匹配作者 (X 大小写不敏感)
+		//   pack:X         → 匹配系列/skinpack
+		//   X              → 匹配皮肤名
+		// 多个 token 用空格分隔，AND 关系。
+		// 带空格的 pack/作者可用双引号包裹：pack:"The Rotting Halls"
+		// 用 shlex 风格 tokenizer 拆分（支持引号），避免 "The Rotting Halls" 被切碎。
+		function tokenize(query: string): string[] {
+			const tokens: string[] = [];
+			let buf = '';
+			let inQuote: '"' | "'" | null = null;
+			for (const ch of query) {
+				if (inQuote) {
+					if (ch === inQuote) {
+						inQuote = null;
+					} else {
+						buf += ch;
+					}
+				} else if (ch === '"' || ch === "'") {
+					inQuote = ch;
+				} else if (ch === ' ' || ch === '\t') {
+					if (buf) {
+						tokens.push(buf);
+						buf = '';
+					}
+				} else {
+					buf += ch;
+				}
+			}
+			if (buf) tokens.push(buf);
+			return tokens;
+		}
+
+		function buildMatcher(query: string) {
+			const tokens = tokenize(query);
+			if (tokens.length === 0) return () => true;
+
+			return (skin: typeof data.skins[number]) => {
+				return tokens.every((tok) => {
+					const lower = tok.toLowerCase();
+					if (lower.startsWith('author:')) {
+						const needle = lower.slice('author:'.length);
+						return needle !== '' && skin.creator.toLowerCase().includes(needle);
+					}
+					if (lower.startsWith('pack:')) {
+						const needle = lower.slice('pack:'.length);
+						return (
+							needle !== '' &&
+							!!skin.skinpack &&
+							skin.skinpack.toLowerCase().includes(needle)
+						);
+					}
+					return skin.name.toLowerCase().includes(lower);
+				});
+			};
+		}
+
+		const matcher = buildMatcher(searchQuery);
+
 		// Filter skins based on search query and community toggle
 		const filtered = data.skins
 			.filter((skin) => {
@@ -26,13 +85,7 @@
 					return false;
 				}
 
-				// Filter by search query
-				const matchesSearch =
-					searchQuery === '' || skin.name.toLowerCase().includes(searchQuery.toLowerCase());
-
-				// For now, we don't have actual type information, so the toggle doesn't do anything
-				// In a real implementation, we would filter by skin.type here
-				return matchesSearch;
+				return matcher(skin);
 			})
 			.sort((a, b) => -a.date.localeCompare(b.date));
 
@@ -86,6 +139,19 @@
 	function getTooltipContent(skinName: string) {
 		return copiedSkin === skinName ? `${skinName} 已复制！` : `${skinName} 点击复制`;
 	}
+
+	// 皮肤卡片点击作者/系列时调用：直接替换搜索框内容为对应的过滤 token。
+	// 替换而不是累加：用户点击即"我想按这个字段筛"，避免堆出无意义的 AND。
+	// 含空格的 pack/作者自动用双引号包裹，避免被 tokenizer 切碎。
+	function quoteIfNeeded(value: string): string {
+		return /\s/.test(value) ? `"${value}"` : value;
+	}
+	function searchByAuthor(name: string) {
+		searchField = `author:${quoteIfNeeded(name)}`;
+	}
+	function searchByPack(name: string) {
+		searchField = `pack:${quoteIfNeeded(name)}`;
+	}
 </script>
 
 <svelte:head>
@@ -126,9 +192,29 @@
 			<input
 				type="text"
 				bind:value={searchField}
-				placeholder="搜索皮肤..."
-				class="w-full rounded-md bg-slate-700 py-2 pr-4 pl-10 text-slate-300 placeholder-slate-400 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+				placeholder="搜索皮肤…"
+				class="w-full rounded-md bg-slate-700 py-2 pr-9 pl-10 text-slate-300 placeholder-slate-400 focus:ring-2 focus:ring-blue-500 focus:outline-none"
 			/>
+			{#if searchField}
+				<button
+					type="button"
+					onclick={() => (searchField = '')}
+					aria-label="清空搜索"
+					title="清空搜索"
+					class="absolute inset-y-0 right-0 flex items-center pr-3 text-slate-400 hover:text-slate-200"
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 20 20"
+						fill="currentColor"
+						class="h-4 w-4"
+					>
+						<path
+							d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z"
+						/>
+					</svg>
+				</button>
+			{/if}
 		</div>
 
 		<!-- Community skins toggle -->
@@ -159,6 +245,8 @@
 							{copiedSkin}
 							{copySkinName}
 							{getTooltipContent}
+							{searchByAuthor}
+							{searchByPack}
 						/>
 					</div>
 				{/each}

--- a/src/routes/ddnet/skins/+page.svelte
+++ b/src/routes/ddnet/skins/+page.svelte
@@ -36,7 +36,10 @@
 			})
 			.sort((a, b) => -a.date.localeCompare(b.date));
 
-		// Split skins into three columns
+		// Group skins into rows of 3 for the desktop 3-column layout.
+		// The wrapper uses `block w-full sm:inline-block sm:w-1/3`, so on mobile
+		// each card stacks to its own line (single column) while on desktop
+		// three cards sit side-by-side per row.
 		const result = [];
 		for (let i = 0; i < filtered.length; i += 3) {
 			result.push({
@@ -146,11 +149,11 @@
 	</p>
 
 	<!-- Skins grid with virtual scrolling -->
-	<div class="scrollbar-subtle grid h-[calc(100svh-16rem)] w-full sm:h-[calc(100svh-14rem)]">
+	<div class="scrollbar-subtle h-[calc(100svh-16rem)] w-full sm:h-[calc(100svh-14rem)]">
 		<VirtualScroll keeps={20} data={filteredSkins} key="row" let:data>
 			<div class="h-20 w-full overflow-hidden">
 				{#each data.skins as skin}
-					<div class="inline-block w-1/3 p-1">
+					<div class="block w-full p-1 sm:inline-block sm:w-1/3">
 						<SkinCard
 							{skin}
 							{copiedSkin}


### PR DESCRIPTION
## Summary

Two commits that together make the skin list page more usable across screen
sizes and easier to filter:

1. **Mobile layout** — single column on `< sm`, 3-column grid on `≥ sm`,
   with all skin info (preview + name + author + skinpack + type + date)
   visible at every breakpoint.
2. **Layout polish + filtering** — compact card layout that fits an 80px
   row, row height fix, tooltip clipping fix, and a new `author:` / `pack:`
   search syntax with clickable author / skinpack badges.

## Changes

### `src/routes/ddnet/skins/+page.svelte` (+103/-12)

**Responsive layout (commit 1):**
- Card wrapper class: `inline-block w-1/3` → `block w-full sm:inline-block sm:w-1/3`
  - Mobile (`< sm`): each wrapper becomes block-level full-width, so the 3
    cards in a VirtualScroll row stack vertically into a single column.
  - Desktop (`≥ sm`): unchanged 3-column grid.
- Outer container: dropped the `grid` class (no longer needed).
- Comment updated to explain the responsive grouping.

**Row height + search syntax (commit 2):**
- Row wrapper: `h-[88px]` → `h-20` (80px) so cards no longer overflow the
  VirtualScroll row container.
- Search box: `pr-4` → `pr-9` to make room for the new clear button.
- New clear-search button (× icon) shown when the field is non-empty.
- Replaced inline `matchesSearch` filter with a `buildMatcher(query)`
  helper that supports `author:X` / `pack:X` / name tokens, with
  shlex-style quoting for values containing spaces (e.g.
  `pack:"The Rotting Halls"`). Multiple tokens are AND-combined.
- New `searchByAuthor(name)` / `searchByPack(name)` callbacks that
  replace the search field with the corresponding `author:` / `pack:`
  token (auto-quoted if the value contains whitespace). Passed down to
  `<SkinCard>`.

### `src/lib/components/SkinCard.svelte` (+95/-29)

**Responsive info visibility (commit 1):**
- Name / author / skinpack block: `hidden sm:flex` → `flex`. Visible on
  every breakpoint.
- Type / date block: `hidden xl:flex` → `flex sm:hidden xl:flex`. Visible
  on mobile and on `xl+`, hidden on the `sm..xl` band — matches the
  original desktop layout where this block only appears on wide screens.

**Compact layout + clickable badges (commit 2):**
- Whole card reworked into a horizontal layout (`flex items-center
  gap-3`) with a fixed `64×64` preview container (`h-16 w-16 shrink-0`)
  so the preview keeps a 1:1 aspect ratio regardless of text length.
- Wrapper padding reduced (`p-4` → `p-1 pr-9`) so cards fit cleanly
  inside the 80px row container.
- Author and skinpack are now clickable buttons (when the corresponding
  callback is provided) that drive the new `author:` / `pack:` search.
  They fall back to plain `<span>` if the callback is omitted, so
  `<SkinCard>` stays reusable.
- Skinpack label moved to the top-right corner of the card (absolute
  positioned, small italic slate-500) so it doesn't compete with the
  name / author line for space.
- Type / date badges grouped into a single absolute-positioned block in
  the bottom-right corner: type badge (blue `官方` / purple `社区`)
  above the date badge (`YYYY-MM-DD`). `pointer-events-none` so they
  don't intercept clicks on the underlying card.

### `src/lib/tippy.ts` (+6/-1)

- Default `appendTo` changed from `'parent'` to `'body'` so tooltips are
  not clipped by `overflow-hidden` on row containers (e.g. VirtualScroll
  rows with fixed height). Floating UI's `computePosition` still places
  the tooltip correctly because it uses the reference element's absolute
  position. Per-call `appendTo` props can still override this default.

## Visual verification

- **Mobile (412×915)**: single column, 999 skins, each card shows preview
  + name + author + skinpack + type + date. Badges and tooltip still
  readable inside the 80px row. ✅
- **Desktop (1920×1080)**: 3-column grid, cards horizontal (preview left,
  text right), all info shown. ✅
- **Search**: typing `tee` filters to 62 matching skins. Typing
  `pack:"The Rotting Halls"` filters by skinpack with quoted value.
  Typing `author:deen` filters by author. Clicking an author badge
  replaces the search field with `author:<name>`. Layout still
  responsive. ✅
- **Tooltip**: hovering over a skin name shows the tooltip above the
  card; no longer clipped by the row container. ✅

## Test plan

- [x] Mobile single column with full info (412×915 viewport)
- [x] Desktop 3-column grid unchanged (1920×1080 viewport)
- [x] Search filtering by name (`tee`)
- [x] Search filtering by `author:deen` / `pack:"The Rotting Halls"`
- [x] Clickable author / skinpack badges replace search field
- [x] Clear-search button appears and works
- [x] Tooltips render outside row containers (no clipping)
- [x] `svelte-kit sync` passes with no errors
